### PR TITLE
Support `OverrideHost` when manipulating backends

### DIFF
--- a/backend.go
+++ b/backend.go
@@ -14,6 +14,7 @@ type Backend struct {
 
 	Name                string `json:"name,omitempty"`
 	Port                uint   `json:"port,omitempty"`
+	OverrideHost        string `json:"override_host,omitempty"`
 	ConnectTimeout      uint   `json:"connect_timeout,omitempty"`
 	MaxConn             uint   `json:"max_conn,omitempty"`
 	ErrorThreshold      uint   `json:"error_threshold"`


### PR DESCRIPTION
Backends allow setting `override_host` when defining them in case we
need fastly to set a different `Host` header when forwarding traffic to
them.

Adding it to the `Backend` structure will allow us to be able to set it
programmatically.