### PR TITLE
Allow mesage_type to be empty on S3 logging

### DIFF
--- a/s3.go
+++ b/s3.go
@@ -25,7 +25,7 @@ type S3 struct {
 	ResponseCondition string      `json:"response_condition"`
 	TimestampFormat   string      `json:"timestamp_format"`
 	Redundancy        string      `json:"redundancy"`
-	MessageType       MessageType `json:"message_type"`
+	MessageType       MessageType `json:"message_type,omitempty"`
 }
 
 type MessageType int


### PR DESCRIPTION
When the value is not set we attempted to pass a nil value to fastly,
which is now a value their API allows. We can omit this field if it's
empty and the API will just revert to the default (classic) if it's not present.